### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gitguardian.yml
+++ b/.github/workflows/gitguardian.yml
@@ -1,5 +1,8 @@
 name: GitGuardian Scan
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Chill-Pangos/Linkoma-BE/security/code-scanning/1](https://github.com/Chill-Pangos/Linkoma-BE/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should explicitly limit the `GITHUB_TOKEN` permissions to the least privilege required for the workflow to function correctly. In this case, the workflow only needs to read repository contents, so we will set `contents: read` at the root level of the workflow. This ensures that all jobs in the workflow inherit these minimal permissions unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
